### PR TITLE
replace tests_require option in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
     maintainer_email='s.wakida@tecgihan.co.jp',
     description='Linux and ROS driver software for Tec Gihan sensor amplifiers for robots',
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': ['pytest'],
+    },
     entry_points={
         'console_scripts': [
             'dma03_ros_publisher = tecgihan_driver.dma03_ros_publisher:main',


### PR DESCRIPTION
I replaced the `tests_require` option with `extras_require` to adapt to newer version setuptools.